### PR TITLE
Bugfix - remaining bounty points not calculating correctly at all times

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Beyond adding basic functionality, I also think it would be interesting to explo
 
 When spending bounty points, in order to update a stat in the database, I needed each stat upgrade to reference a specific place in that character's JSON document. I wanted this to be a generic function that could apply regardless of whether the player is updating a Trait, an attribute (which is a child of a trait), or a concentration (which is a child of an attribute).
 
-Within [stat_upgrade_button.js](https://github.com/garretdepass/deadlands-dice-roller/blob/main/src/components/stat_upgrade_button.js), I created a function that returns any stat's index dynamically.
+Within [stat_upgrade_button.jsx](https://github.com/garretdepass/deadlands-dice-roller/blob/main/src/components/stat_upgrade_button.jsx), I created a function that returns any stat's index dynamically.
 
 ```javascript
 const jsonStatIndex = () => {
@@ -221,6 +221,7 @@ const handleAttributeOrConcentrationClick = () => {
       upgradeType: "dieCount",
     };
     setUpgradesArray([...upgradesArray, newUpgrade]);
+    setRemainingBountyPoints((previousValue) => previousValue - cost);
   } else {
     popover.showPopover();
   }
@@ -229,7 +230,7 @@ const handleAttributeOrConcentrationClick = () => {
 
 ## Rolling dice
 
-The way Deadlands handles dice rolling is rather unusual, so the code to handle it was a lot of fun to write! Within [roll_panel.js](https://github.com/garretdepass/deadlands-dice-roller/blob/main/src/components/roll_panel.js), it starts by creating an array of dice to roll based on which stat the player selects. This is used to display the pre-rolled state.
+The way Deadlands handles dice rolling is rather unusual, so the code to handle it was a lot of fun to write! Within [roll_panel.jsx](https://github.com/garretdepass/deadlands-dice-roller/blob/main/src/components/roll_panel.jsx), it starts by creating an array of dice to roll based on which stat the player selects. This is used to display the pre-rolled state.
 
 ```javascript
 const generateDiceArray = (dieCountToRoll, dieSidesToRoll) => {

--- a/src/components/character_view.jsx
+++ b/src/components/character_view.jsx
@@ -34,7 +34,7 @@ const CharacterView = ({ character, characterIndex }) => {
     };
     fetchData();
 
-    setRemainingBountyPoints(currentCharacter.bountyPoints);
+    // setRemainingBountyPoints(currentCharacter.bountyPoints);
   }, [upgradesArray]);
 
   useEffect(() => {
@@ -101,6 +101,7 @@ const CharacterView = ({ character, characterIndex }) => {
     if (stat === "bountyPoints") {
       newBountyPoints++;
       setBountyPoints(newBountyPoints);
+      setRemainingBountyPoints((previousValue) => previousValue + 1);
       await updateStat(character._id, "bountyPoints", newBountyPoints);
     } else if (stat === "wind") {
       if (returnTotalWind() > currentWind) {
@@ -117,6 +118,7 @@ const CharacterView = ({ character, characterIndex }) => {
       if (bountyPoints > 0) {
         newBountyPoints--;
         setBountyPoints(newBountyPoints);
+        setRemainingBountyPoints((previousValue) => previousValue - 1);
         await updateStat(character._id, "bountyPoints", newBountyPoints);
       }
     } else if (stat === "wind") {
@@ -161,6 +163,7 @@ const CharacterView = ({ character, characterIndex }) => {
                 setUpgradesArray={setUpgradesArray}
                 character={character}
                 remainingBountyPoints={remainingBountyPoints}
+                setRemainingBountyPoints={setRemainingBountyPoints}
               />
             )}
           </div>
@@ -188,6 +191,7 @@ const CharacterView = ({ character, characterIndex }) => {
                 setUpgradesArray={setUpgradesArray}
                 character={character}
                 remainingBountyPoints={remainingBountyPoints}
+                setRemainingBountyPoints={setRemainingBountyPoints}
               />
             )}
           </div>

--- a/src/components/menu.jsx
+++ b/src/components/menu.jsx
@@ -13,6 +13,7 @@ const Menu = ({
   character,
   jsonStatIndex,
   remainingBountyPoints,
+  setRemainingBountyPoints,
 }) => {
   const cost = (upgradeType) => {
     if (upgradeType === "dieCount") {
@@ -41,6 +42,7 @@ const Menu = ({
         upgradeType: upgradeType,
       };
       setUpgradesArray([...upgradesArray, newUpgrade]);
+      setRemainingBountyPoints((previousValue) => previousValue - upgradeCost);
     }
   };
 

--- a/src/components/spend_bounty_points_panel.jsx
+++ b/src/components/spend_bounty_points_panel.jsx
@@ -35,6 +35,7 @@ const SpendBountyPointsPanel = ({
           upgradesArray={upgradesArray}
           setUpgradesArray={setUpgradesArray}
           element={element}
+          setRemainingBountyPoints={setRemainingBountyPoints}
         />
       );
     });
@@ -60,6 +61,7 @@ const SpendBountyPointsPanel = ({
   const handleBountyPointsPanelCancel = () => {
     setUpgradesArray([]);
     setTotalBountyPointsToSpend(0);
+    setRemainingBountyPoints(bountyPoints);
     setHasEnoughBountyPoints(true);
   };
 
@@ -102,13 +104,8 @@ const SpendBountyPointsPanel = ({
       setBountyPoints(remainingBountyPoints);
       setUpgradesArray([]);
       setTotalBountyPointsToSpend(0);
-      setRemainingBountyPoints(0);
     }
   };
-
-  useEffect(() => {
-    setRemainingBountyPoints(bountyPoints - totalBountyPointsToSpend);
-  }, [totalBountyPointsToSpend, bountyPoints]);
 
   return (
     <div className="panel panel__panel-right">

--- a/src/components/stat_upgrade_button.jsx
+++ b/src/components/stat_upgrade_button.jsx
@@ -11,6 +11,7 @@ const StatUpgradeButton = ({
   character,
   hasEnoughBountyPoints,
   remainingBountyPoints,
+  setRemainingBountyPoints,
 }) => {
   const returnButtonText = () => {
     switch (statType) {
@@ -100,7 +101,9 @@ const StatUpgradeButton = ({
         jsonStatIndex: jsonStatIndex(),
         upgradeType: "dieCount",
       };
-      setUpgradesArray([...upgradesArray, newUpgrade]);
+
+      setUpgradesArray((previousArray) => [...previousArray, newUpgrade]);
+      setRemainingBountyPoints((previousValue) => previousValue - cost);
     } else {
       popover.showPopover();
     }
@@ -154,6 +157,7 @@ const StatUpgradeButton = ({
             character={character}
             jsonStatIndex={jsonStatIndex()}
             remainingBountyPoints={remainingBountyPoints}
+            setRemainingBountyPoints={setRemainingBountyPoints}
           />
         )}
       </div>

--- a/src/components/upgrade_row.jsx
+++ b/src/components/upgrade_row.jsx
@@ -2,7 +2,12 @@ import React, { useState } from "react";
 import "./upgrade_row.css";
 import "../App.css";
 
-const UpgrageRow = ({ element, upgradesArray, setUpgradesArray }) => {
+const UpgrageRow = ({
+  element,
+  upgradesArray,
+  setUpgradesArray,
+  setRemainingBountyPoints,
+}) => {
   const returnUpgradeDetails = () => {
     if (element.upgradeType === "dieSides") {
       return (
@@ -30,6 +35,7 @@ const UpgrageRow = ({ element, upgradesArray, setUpgradesArray }) => {
       }
     }
     setUpgradesArray(newArray);
+    setRemainingBountyPoints((previousValue) => previousValue + element.cost);
   };
 
   return (


### PR DESCRIPTION
Now, remaining bounty points are calculated accurately. I removed a useEffect hook and converted the functionality into specific useState functionality, setting the state intentionally only in specific places. Remaining bounty points are now recalculated:

- on spend bounty point button click
- on spend bounty point menu item click
- on bounty point increment/decrement
- on cancel button click
- on spend button click
- on delete upgrade row item